### PR TITLE
Redesign README, add third line support, fix token resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Copilot CLI Status Line
 
-A Windows PowerShell status line for [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) that renders live session metrics, workspace stats, and Copilot quota pacing directly in the terminal. The segment order is user-configurable from the top of `statusline.ps1`.
+A customizable status line for [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) that keeps the important session details visible right in your terminal: model, context usage, token spend, session duration, premium requests, quota pace, current folder, and lines changed.
 
 ![Windows](https://img.shields.io/badge/platform-Windows-blue)
 ![PowerShell 7+](https://img.shields.io/badge/PowerShell-7%2B-5391FE)
@@ -8,31 +8,46 @@ A Windows PowerShell status line for [GitHub Copilot CLI](https://docs.github.co
 
 ## What It Shows
 
-The current script renders **two configurable lines**. The default layout is:
+The script can render **up to three configurable lines**. By default, it uses the first two and leaves the third line empty, so nothing extra is printed.
+
+The first line is the "how is this session going?" line: it shows the active model, how full the context window is, how many input/output tokens have been spent, how long the session has been running, how many premium requests this session has used, and whether your monthly premium quota is currently running **behind pace** (good), **on pace**, or **ahead of budget** (bad).
+
+The second line is the "where am I and what changed?" line: it shows the current working directory and the session's cumulative added/removed lines so you can keep your bearings while you work.
+
+The third line is available for any extra segments you want, but it is **disabled by default**.
+
+The default layout is:
 
 ```text
-gpt-5.4 (high) | ██████████ 22% 400K | in 1.7M out 27K | 54m | 5 p.req. | Quota: ████████░░░░░░░░░░░░░░░░░░░░░░ 3.2 days behind (160 p.req.)
+gpt-5.4 (high) | ██████████ 22% 400K | in 1.7M out 27K | 54m | 5 p.req. | Quota: ████████░░░░░░░░░░░░░░░░░░░░░░ 3.2d behind (160 p.req.)
 D:\GITHUB\my-project | +695 -146
 ```
+
 <img width="1905" height="181" alt="Status line screenshot" src="./assets/readme-statusline.png" />
 
-### Line 1 - Session Status
+### Line 1 - Session Overview
 
-| Segment | Description |
-|---------|-------------|
-| **Model** | `model.display_name`, falling back to `model.id` |
-| **Context usage** | 10-cell bar, rounded percent used, and context window size |
-| **Tokens** | Cumulative `in` / `out` token totals |
-| **Duration** | Session wall-clock time rounded to whole minutes |
-| **Premium requests** | `cost.total_premium_requests` |
-| **Quota** | Month calendar overlay showing quota pace relative to the current day |
+| Segment | What it tells you | Source field(s) | Notes |
+|---------|-------------------|-----------------|-------|
+| **Model** | Which model is answering right now | `model.display_name`, fallback `model.id` | Shown in cyan |
+| **Context usage** | How full the current context window is | `context_window.used_percentage`, `context_window.context_window_size` | Renders a 10-cell bar, rounded percent, and compact size |
+| **Tokens** | How many input and output tokens the session has spent so far | `context_window.total_input_tokens`, `context_window.total_output_tokens` | Shows `in` and `out` totals |
+| **Duration** | How long the session has been running | `cost.total_duration_ms` | Rounded to whole minutes; hidden under 30 seconds |
+| **Premium requests** | How many premium requests this session has used | `cost.total_premium_requests` | Rendered as `N p.req.` |
+| **Quota** | Whether monthly premium usage is behind pace, on pace, ahead, or exceeded | GitHub Copilot quota API: `quota_snapshots.premium_interactions.percent_remaining`, `quota_snapshots.premium_interactions.entitlement` | Uses a month-shaped calendar bar |
 
-### Line 2 - Workspace Status
+### Line 2 - Workspace Overview
 
-| Segment | Description |
-|---------|-------------|
-| **Path** | `cwd`, falling back to `workspace.current_dir` |
-| **Lines changed** | `+added` in green and `-removed` in red from the Copilot payload |
+| Segment | What it tells you | Source field(s) | Notes |
+|---------|-------------------|-----------------|-------|
+| **Path** | Which folder Copilot currently considers the working directory | `cwd`, fallback `workspace.current_dir` | Uses `Get-Location` if neither is present |
+| **Lines changed** | How many lines were added and removed during this session | `cost.total_lines_added`, `cost.total_lines_removed` | Shows green `+N` and red `-N` |
+
+### Line 3 - Optional Extra Line
+
+| Segment | What it tells you | Source field(s) | Notes |
+|---------|-------------------|-----------------|-------|
+| **Any supported segment** | Anything you want to move off the first two lines | Same as the segment you place there | Empty by default, so no third line is printed |
 
 ## Customizing the Layout
 
@@ -52,48 +67,107 @@ $Line2Layout = @(
     'path'
     'lines_changed'
 )
+
+$Line3Layout = @(
+)
 ```
 
-Remove a segment name to hide it, or reorder the entries to change the display order.
+Remove a segment name to hide it, reorder entries to change display order, or move segments between lines. Leave `$Line3Layout` empty to suppress the third line entirely.
 
 Available segment names:
 
-| Name | Line | Description |
-|------|------|-------------|
-| `model` | 1 | Active model name |
-| `context_bar` | 1 | Context-window usage bar, percent, and size |
-| `tokens` | 1 | Cumulative input / output token totals |
-| `duration` | 1 | Total session wall-clock time |
-| `premium_requests` | 1 | Premium request count (`p.req.`) |
-| `quota` | 1 | Monthly quota pacing segment |
-| `path` | 2 | Current workspace / working directory |
-| `lines_changed` | 2 | `+added` / `-removed` lines from the payload |
+| Segment name | Default line | What it shows | Source field(s) |
+|--------------|--------------|---------------|-----------------|
+| `model` | 1 | Active model name | `model.display_name`, fallback `model.id` |
+| `context_bar` | 1 | Context-window usage bar, rounded percent, and size | `context_window.used_percentage`, `context_window.context_window_size` |
+| `tokens` | 1 | Cumulative input and output token totals | `context_window.total_input_tokens`, `context_window.total_output_tokens` |
+| `duration` | 1 | Session wall-clock time | `cost.total_duration_ms` |
+| `premium_requests` | 1 | Premium request count | `cost.total_premium_requests` |
+| `quota` | 1 | Monthly premium quota pacing indicator | Copilot quota API `percent_remaining`, `entitlement` |
+| `path` | 2 | Current workspace / working directory | `cwd`, fallback `workspace.current_dir` |
+| `lines_changed` | 2 | Added and removed lines from the session payload | `cost.total_lines_added`, `cost.total_lines_removed` |
 
-If `quota` is removed from both layout arrays, the script skips the GitHub quota API call entirely.
+If `quota` is removed from all layout arrays, the script skips the GitHub quota API call entirely.
 
 ## Quota Calendar
 
-The quota segment renders the current month as a compact calendar:
+The quota segment renders the current month as a compact calendar. The label is intentionally inverted from typical schedule language:
 
-- **Solid grey `█`** = elapsed past days outside the pace deviation
-- **Green solid `█`** = behind-pace spillover into previous days
-- **Dark shade `▓`** = today
-- **Red hatched `░`** = ahead-of-pace spillover into future days
-- **Light shade `░`** = future days outside the pace deviation
-- **Red circle + `quota exceeded`** = usage is at or above 100%
+- **behind** = under quota pace (good)
+- **on pace** = close to target
+- **ahead** = over quota pace (bad)
 
-Today is **white only when on pace**. When the user is behind or ahead, the today bar switches to the matching pace color and stays rendered as a dark shade `▓`. The green or red overlay appears only when the time-of-day-aware deviation rounds to at least **0.5 day** of spillover beyond today. For example, **3 days behind** shows three green bars before today plus a green today bar, and **3 days ahead** shows three red hatched bars after a red today bar.
+<table>
+  <tr>
+    <th>Legend</th>
+    <th>Meaning</th>
+  </tr>
+  <tr>
+    <td><code>█</code></td>
+    <td>Past day outside the pace deviation</td>
+  </tr>
+  <tr>
+    <td><code>█</code> in green</td>
+    <td>Behind-pace spillover into previous days</td>
+  </tr>
+  <tr>
+    <td><code>▓</code></td>
+    <td>Today</td>
+  </tr>
+  <tr>
+    <td><code>░</code> in red</td>
+    <td>Ahead-of-pace spillover into future days</td>
+  </tr>
+  <tr>
+    <td><code>░</code></td>
+    <td>Future day outside the pace deviation</td>
+  </tr>
+  <tr>
+    <td><code>🔴 quota exceeded</code></td>
+    <td>Usage reached or passed 100%</td>
+  </tr>
+</table>
 
-When the user is behind pace and the Copilot quota API returns `entitlement`, the label also includes an unrealized premium request hint such as `(160 p.req.)`.
+Today is **white only when on pace**. When usage is behind or ahead, the today bar switches to the matching pace color and stays rendered as a dark shade `▓`. The green or red overlay appears only when the time-of-day-aware deviation rounds to at least **0.5 day** of spillover beyond today.
+
+When the Copilot quota API returns `entitlement`, the pace label also includes a premium request estimate such as `(160 p.req.)`. For **behind**, that number represents requests still available relative to calendar pace; for **ahead**, it represents how many premium requests are already over pace.
 
 If the quota API is unavailable, the script falls back to a dim `Quota: day/month` indicator.
 
 ## Color Rules
 
-- **Context bar**: green under 75%, yellow at 75%+, red at 90%+
-- **Unused context bar cells**: solid grey
-- **Token values only** are colored: bright yellow at 10K+, yellow at 100K+, red at 1M+
-- **Quota pace**: green = behind, white = on pace only, red = ahead
+<table>
+  <tr>
+    <th>Area</th>
+    <th>Rule</th>
+    <th>Example</th>
+  </tr>
+  <tr>
+    <td>Context bar</td>
+    <td>🟢 under 75%, 🟡 at 75%+, 🔴 at 90%+</td>
+    <td><code>██████░░░░ 60%</code>, <code>████████░░ 80%</code>, <code>█████████░ 92%</code></td>
+  </tr>
+  <tr>
+    <td>Unused context cells</td>
+    <td>Dim grey</td>
+    <td><code>██████░░░░</code></td>
+  </tr>
+  <tr>
+    <td>Token values</td>
+    <td>🟡 bright yellow at 10K+, 🟠 yellow at 100K+, 🔴 red at 1M+</td>
+    <td><code>in 27K</code>, <code>in 174K</code>, <code>in 1.7M</code></td>
+  </tr>
+  <tr>
+    <td>Quota pace</td>
+    <td>🟢 behind, ⚪ on pace, 🔴 ahead</td>
+    <td><code>2.4d behind</code>, <code>on pace</code>, <code>1.1d ahead</code></td>
+  </tr>
+  <tr>
+    <td>Lines changed</td>
+    <td>Added lines are green; removed lines are red</td>
+    <td><code>+695 -146</code></td>
+  </tr>
+</table>
 
 ## Requirements
 
@@ -150,7 +224,7 @@ Start a new Copilot CLI session and the status line should appear automatically.
 
 ## Local Testing
 
-There is no automated test suite. The script is intended to be tested by piping sample payloads into `statusline.ps1`.
+There is no automated test suite. Test by piping sample payloads into `statusline.ps1`.
 
 ```powershell
 # Full payload
@@ -166,21 +240,31 @@ echo $null | pwsh -NoProfile -File .\statusline.ps1
 ## How It Works
 
 1. Copilot CLI pipes a JSON payload to stdin on each refresh.
-2. `statusline.ps1` parses the payload and extracts model, token, duration, path, and lines-changed data.
-3. The script fetches quota data from `https://api.github.com/copilot_internal/user` and reads both `percent_remaining` and `entitlement`.
+2. `statusline.ps1` parses the payload and extracts the configured segment values.
+3. The script optionally fetches quota data from `https://api.github.com/copilot_internal/user`.
 4. Quota usage is compared against calendar progress for the current month using time-of-day-aware rounding and spillover-based bar rendering.
 5. The configured line layouts are resolved into segment strings and written to stdout.
 
-### GitHub Token Resolution
+## GitHub Token Resolution
 
-The quota API token is resolved in this order:
+The quota API call runs outside Copilot CLI itself, so the script needs its own way to find a token. Multiple lookup paths are useful because different setups authenticate in different ways.
 
-1. `GITHUB_TOKEN`
+The script currently checks for a token in this order:
+
+1. `COPILOT_GITHUB_TOKEN`
 2. `GH_TOKEN`
-3. `~/.copilot/config.json` → `copilot_tokens`
-4. `git credential fill`
+3. `GITHUB_TOKEN`
+4. `~/.copilot/config.json` → `copilot_tokens`
+5. `gh auth token`
 
-### Debug Logging
+Notes:
+
+- `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, and `GITHUB_TOKEN` are all valid Copilot CLI auth sources for non-interactive setups when the token has the required **Copilot Requests** permission.
+- `~/.copilot/config.json` is only relevant when Copilot CLI stored credentials in plaintext because the system keychain was unavailable.
+- `gh auth token` is a better fallback than `git credential fill` for this script because Copilot CLI officially supports GitHub CLI auth fallback, while generic Git credentials may not match the token Copilot uses.
+- The script does **not** read the Windows Credential Manager directly. If your Copilot login lives only there, use an environment variable or sign in with `gh` if you want quota lookups to work from the script.
+
+## Debug Logging
 
 `statusline.ps1` has a top-level `$DebugLog` switch. It is currently **off by default**:
 
@@ -192,7 +276,75 @@ When enabled, raw stdin payloads are appended to `statusline.stdin.log` next to 
 
 ## Payload Parameters
 
-The header comment in `statusline.ps1` lists all known stdin payload fields and marks which ones are currently used.
+The Copilot CLI pipes a JSON object to stdin on each refresh. Two payload shapes are common:
+
+- **Minimal payload**: usually just `context_window` when a session starts
+- **Full payload**: includes model, workspace, cost, and context fields
+
+### Top-level fields
+
+| Field | Type | Used now | Meaning |
+|-------|------|----------|---------|
+| `cwd` | `string` | Yes | Current working directory |
+| `session_id` | `string` | No | Unique session identifier |
+| `session_name` | `string` | No | Human-readable session name |
+| `transcript_path` | `string` | No | Path to the session transcript folder |
+| `version` | `string` | No | Copilot CLI version |
+
+### `model`
+
+| Field | Type | Used now | Meaning |
+|-------|------|----------|---------|
+| `model.id` | `string` | Yes | Model identifier such as `gpt-5.4` |
+| `model.display_name` | `string` | Yes | Friendly display name |
+
+### `workspace`
+
+| Field | Type | Used now | Meaning |
+|-------|------|----------|---------|
+| `workspace.current_dir` | `string` | Yes | Workspace root directory |
+
+### `cost`
+
+| Field | Type | Used now | Meaning |
+|-------|------|----------|---------|
+| `cost.total_api_duration_ms` | `int` | No | Cumulative API call time in milliseconds |
+| `cost.total_lines_added` | `int` | Yes | Total lines added in this session |
+| `cost.total_lines_removed` | `int` | Yes | Total lines removed in this session |
+| `cost.total_duration_ms` | `int` | Yes | Total session wall-clock time in milliseconds |
+| `cost.total_premium_requests` | `int` | Yes | Premium request count for this session |
+
+### `context_window`
+
+| Field | Type | Used now | Meaning |
+|-------|------|----------|---------|
+| `context_window.total_input_tokens` | `int` | Yes | Cumulative input tokens |
+| `context_window.total_output_tokens` | `int` | Yes | Cumulative output tokens |
+| `context_window.total_cache_read_tokens` | `int` | No | Tokens served from cache |
+| `context_window.total_cache_write_tokens` | `int` | No | Tokens written to cache |
+| `context_window.total_tokens` | `int` | No | Sum of input and output tokens |
+| `context_window.context_window_size` | `int` | Yes | Max context window size |
+| `context_window.used_percentage` | `int` | Yes | Percent of context window used |
+| `context_window.remaining_percentage` | `int` | No | Percent of context window free |
+| `context_window.remaining_tokens` | `int` | No | Tokens still available |
+| `context_window.last_call_input_tokens` | `int` | No | Input tokens in the last call |
+| `context_window.last_call_output_tokens` | `int` | No | Output tokens in the last call |
+
+### `context_window.current_usage`
+
+| Field | Type | Used now | Meaning |
+|-------|------|----------|---------|
+| `context_window.current_usage.input_tokens` | `int` | No | Raw input tokens used |
+| `context_window.current_usage.output_tokens` | `int` | No | Raw output tokens used |
+| `context_window.current_usage.cache_creation_input_tokens` | `int` | No | Cache creation tokens |
+| `context_window.current_usage.cache_read_input_tokens` | `int` | No | Cache read tokens |
+
+### External API used by the script
+
+| Source | Used now | Meaning |
+|--------|----------|---------|
+| GitHub Copilot quota API `quota_snapshots.premium_interactions.percent_remaining` | Yes | Remaining premium quota percentage |
+| GitHub Copilot quota API `quota_snapshots.premium_interactions.entitlement` | Yes | Monthly premium request budget used to estimate pace hints |
 
 ## License
 

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -18,6 +18,9 @@ $DebugLog = $false
 #   path               - Current workspace / working directory
 #   lines_changed      - Lines added / removed this session (+N -N)
 #
+# Line 3 segment names:
+#   (empty by default — add any segment names you want on a third line)
+#
 $Line1Layout = @(
     'model'
     'context_bar'
@@ -31,66 +34,23 @@ $Line2Layout = @(
     'path'
     'lines_changed'
 )
+
+$Line3Layout = @(
+)
 # ─────────────────────────────────────────────────────────────────────────────
 
 # Copilot CLI Status Line Script (Windows PowerShell)
 #
-# Renders a two-line status bar from Copilot's JSON payload piped to stdin.
+# Renders up to three configurable status lines from Copilot's JSON payload piped to stdin.
 #
 # LINE 1: model | context bar % size | in/out tokens | duration | p.req. | quota pace
 #         (configurable — see $Line1Layout above)
 # LINE 2: cwd path | +lines -lines
 #         (configurable — see $Line2Layout above)
+# LINE 3: disabled by default
+#         (configurable — see $Line3Layout above)
 #
-# ─── STDIN PAYLOAD PARAMETERS ────────────────────────────────────────────────
-#
-# The Copilot CLI pipes a JSON object to stdin on each status refresh.
-# Two payload shapes exist: a minimal one (context-only) and a full one.
-#
-# Top-level fields:
-#   cwd                         string   Current working directory              ✅ USED (line 2 path)
-#   session_id                  string   Unique session identifier              ○  available
-#   session_name                string   Human-readable session name            ○  available
-#   transcript_path             string   Path to session transcript folder      ○  available
-#   version                     string   Copilot CLI version (e.g. "1.0.20")   ○  available
-#
-# model:
-#   model.id                    string   Model identifier (e.g. "gpt-5.4")     ✅ USED (fallback name)
-#   model.display_name          string   Friendly model name                    ✅ USED (line 1 model)
-#
-# workspace:
-#   workspace.current_dir       string   Workspace root directory               ✅ USED (fallback for cwd)
-#
-# cost:
-#   cost.total_api_duration_ms  int      Cumulative API call time in ms         ○  available
-#   cost.total_lines_added      int      Total lines added this session         ✅ USED (line 2 green +N)
-#   cost.total_lines_removed    int      Total lines removed this session       ✅ USED (line 2 red -N)
-#   cost.total_duration_ms      int      Total session wall-clock time in ms    ✅ USED (line 1 duration)
-#   cost.total_premium_requests int      Premium request count this session     ✅ USED (line 1 p.req.)
-#
-# context_window:
-#   context_window.total_input_tokens       int   Cumulative input tokens       ✅ USED (line 1 "in")
-#   context_window.total_output_tokens      int   Cumulative output tokens      ✅ USED (line 1 "out")
-#   context_window.total_cache_read_tokens  int   Tokens served from cache      ○  available
-#   context_window.total_cache_write_tokens int   Tokens written to cache       ○  available
-#   context_window.total_tokens             int   Sum of input + output tokens  ○  available
-#   context_window.context_window_size      int   Max context window size       ✅ USED (line 1 size)
-#   context_window.used_percentage          int   % of context window used      ✅ USED (line 1 bar + %)
-#   context_window.remaining_percentage     int   % of context window free      ○  available
-#   context_window.remaining_tokens         int   Tokens still available        ○  available
-#   context_window.last_call_input_tokens   int   Input tokens in last call     ○  available
-#   context_window.last_call_output_tokens  int   Output tokens in last call    ○  available
-#
-# context_window.current_usage:
-#   current_usage.input_tokens              int   Raw input tokens used         ○  available
-#   current_usage.output_tokens             int   Raw output tokens used        ○  available
-#   current_usage.cache_creation_input_tokens int  Cache creation tokens        ○  available
-#   current_usage.cache_read_input_tokens   int   Cache read tokens             ○  available
-#
-# External API (not from stdin):
-#   GitHub Copilot quota API → percent_remaining, entitlement                  ✅ USED (quota pace)
-#
-# ─── END PARAMETERS ──────────────────────────────────────────────────────────
+# The full stdin payload field reference lives in README.md.
 
 # ─── UTF-8 Encoding ──────────────────────────────────────────────────────────
 # Force UTF-8 so the status line runner preserves block characters and emoji.
@@ -385,10 +345,11 @@ function Get-LinesChangedStats($payload) {
     return "$addedStr $removedStr"
 }
 
-# Resolves a GitHub token from env vars, Copilot config, or git credential store.
+# Resolves a GitHub token from supported env vars, plaintext Copilot config, or gh CLI.
 function Get-GitHubAccessToken {
-    if ($env:GITHUB_TOKEN) { return $env:GITHUB_TOKEN }
+    if ($env:COPILOT_GITHUB_TOKEN) { return $env:COPILOT_GITHUB_TOKEN }
     if ($env:GH_TOKEN) { return $env:GH_TOKEN }
+    if ($env:GITHUB_TOKEN) { return $env:GITHUB_TOKEN }
 
     $copilotCfgPath = Join-Path $env:USERPROFILE ".copilot\config.json"
     if (Test-Path $copilotCfgPath) {
@@ -412,10 +373,9 @@ function Get-GitHubAccessToken {
     }
 
     try {
-        $git = Get-Command git -ErrorAction Stop
-        $credentialLines = "url=https://github.com" | & $git.Source credential fill 2>$null
-        $passwordLine = $credentialLines | Select-String "^password="
-        if ($passwordLine) { return $passwordLine.ToString().Split("=", 2)[1] }
+        $gh = Get-Command gh -ErrorAction Stop
+        $token = (& $gh.Source auth token 2>$null | Out-String).Trim()
+        if (-not [string]::IsNullOrWhiteSpace($token)) { return $token }
     } catch {}
 
     return $null
@@ -494,8 +454,16 @@ function Get-QuotaPaceSegment($quotaData) {
         $barCount  = [int][math]::Round($spillover, [System.MidpointRounding]::AwayFromZero)
         if ($barCount -gt 0) {
             $futureRedBars = [math]::Min($barCount, $futureCount)
+            
+            # p.req. hint: requests that exceeded expected pace.
+            $pReqHint = ""
+            if ($null -ne $entitlement) {
+                $pReq = [int][math]::Round($daysDelta / $daysInMonth * $entitlement, [System.MidpointRounding]::AwayFromZero)
+                if ($pReq -gt 0) { $pReqHint = " ($pReq p.req.)" }
+            }
+            
             $cal = "$dim$($filledChar * $todayIndex)$rst$red$darkShadeChar$($hatchedChar * $futureRedBars)$rst$dim$($hatchedChar * ($futureCount - $futureRedBars))$rst"
-            return "Quota: $cal $red$('{0:0.0}' -f $daysDelta)d $aheadText$rst"
+            return "Quota: $cal $red$('{0:0.0}' -f $daysDelta)d $aheadText$pReqHint$rst"
         }
     }
 
@@ -535,7 +503,7 @@ Write-StdinLog $rawStdin
 $contextPayload = ConvertFrom-JsonObjectOrNull $rawStdin
 
 # ─── Fetch quota data once (skipped if 'quota' is not in any layout) ─────────
-$allLayoutSegments = $Line1Layout + $Line2Layout
+$allLayoutSegments = $Line1Layout + $Line2Layout + $Line3Layout
 $quotaData = if ($allLayoutSegments -contains 'quota') { Get-CopilotQuotaData } else { $null }
 
 # ─── Segment resolver ────────────────────────────────────────────────────────
@@ -577,6 +545,12 @@ function Resolve-Segment([string]$name) {
 # ─── Build and output each line ──────────────────────────────────────────────
 $line1Segments = $Line1Layout | ForEach-Object { Resolve-Segment $_ }
 $line2Segments = $Line2Layout | ForEach-Object { Resolve-Segment $_ }
+$line3Segments = $Line3Layout | ForEach-Object { Resolve-Segment $_ }
 
 Write-Output (Join-StatusSegments $line1Segments)
 Write-Output (Join-StatusSegments $line2Segments)
+
+$line3 = Join-StatusSegments $line3Segments
+if (-not [string]::IsNullOrWhiteSpace($line3)) {
+    Write-Output $line3
+}


### PR DESCRIPTION
- Add optional third layout line (Line3Layout) to support up to 3 output lines
- Fix GitHub token resolution to use official Copilot CLI auth sources
- Redesign README with human-friendly descriptions
- Move full stdin payload field reference from script to README
- Replace quota legend and color rules with HTML tables and examples
- Clarify token resolution strategy